### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -19,7 +19,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghrc.io//django-fly
+          images: ghcr.io//django-fly
           tags: |
             type=semver,pattern={{major}}.{{minor}}
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
Hi `PedroH31/DjangoPro`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.